### PR TITLE
Add error handling and new users welcoming

### DIFF
--- a/api/vk-callback.ts
+++ b/api/vk-callback.ts
@@ -20,6 +20,8 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         await createSettingsCollections();
         await handleMessage(message);
       }
+    } catch (error) {
+      console.error(error);
     } finally {
       res.send("ok");
       return;

--- a/api/vk-callback.ts
+++ b/api/vk-callback.ts
@@ -15,13 +15,15 @@ export default async (req: VercelRequest, res: VercelResponse) => {
   if (data.type === "message_new") {
     const { message } = data.object;
 
-    if (message.from_id > 0) {
-      await createSettingsCollections();
-      await handleMessage(message);
+    try {
+      if (message.from_id > 0) {
+        await createSettingsCollections();
+        await handleMessage(message);
+      }
+    } finally {
+      res.send("ok");
+      return;
     }
-
-    res.send("ok");
-    return;
   }
 
   res.send("ok");

--- a/commands/actionlessModes/welcome.ts
+++ b/commands/actionlessModes/welcome.ts
@@ -1,0 +1,9 @@
+import { ActionlessModeObject } from "..";
+
+const welcome: ActionlessModeObject = {
+  description: "welcome_description",
+  enabledText: "welcome_enabledText",
+  disabledText: "welcome_disabledText",
+};
+
+export default welcome;

--- a/commands/conversationCommands/welcomeRemove.ts
+++ b/commands/conversationCommands/welcomeRemove.ts
@@ -1,0 +1,43 @@
+import { ConversationCommand, ConversationCommandObject } from "..";
+import setChatSettings from "../../utils/database/setChatSettings";
+import { MessageId } from "../../utils/localization/messages";
+import phrase from "../../utils/localization/phrase";
+import vk from "../../utils/vk";
+
+const command: ConversationCommand = async (
+  message,
+  settings,
+  adminContext,
+  callbackServerSettings
+) => {
+  const { peer_id: peerId, text } = message;
+
+  if (settings.welcome === null) {
+    const replyText: MessageId =
+      settings.actionlessModes.welcome === true
+        ? "welcomeRemove_failNoMessageWithModeHint"
+        : "welcomeRemove_failNoMessage";
+
+    await vk.messagesSend(peerId, phrase(replyText));
+    return;
+  }
+
+  await setChatSettings(peerId, {
+    welcome: null,
+  });
+
+  const replyText: MessageId =
+    settings.actionlessModes.welcome === true
+      ? "welcomeRemove_successWithModeHint"
+      : "welcomeRemove_success";
+
+  await vk.messagesSend(peerId, phrase(replyText));
+};
+
+const welcomeRemove: ConversationCommandObject = {
+  command,
+  isAdminCommand: true,
+  description: "welcomeRemove_description",
+};
+
+export default welcomeRemove;

--- a/commands/conversationCommands/welcomeSet.ts
+++ b/commands/conversationCommands/welcomeSet.ts
@@ -1,0 +1,40 @@
+import { ConversationCommand, ConversationCommandObject } from "..";
+import setChatSettings from "../../utils/database/setChatSettings";
+import { MessageId } from "../../utils/localization/messages";
+import phrase from "../../utils/localization/phrase";
+import vk from "../../utils/vk";
+
+const command: ConversationCommand = async (
+  message,
+  settings,
+  adminContext,
+  callbackServerSettings
+) => {
+  const { peer_id: peerId, text } = message;
+
+  const welcomeMessage = text.slice(text.indexOf(" ")).trim();
+
+  if (welcomeMessage.length === 0) {
+    await vk.messagesSend(peerId, phrase("welcomeSet_failNoMessage"));
+    return;
+  }
+
+  await setChatSettings(peerId, {
+    welcome: welcomeMessage,
+  });
+
+  const replyText: MessageId =
+    settings.actionlessModes.welcome === true
+      ? "welcomeSet_success"
+      : "welcomeSet_successWithModeHint";
+
+  await vk.messagesSend(peerId, phrase(replyText));
+};
+
+const welcomeSet: ConversationCommandObject = {
+  command,
+  isAdminCommand: true,
+  description: "welcomeSet_description",
+};
+
+export default welcomeSet;

--- a/commands/conversationCommands/welcomeSet.ts
+++ b/commands/conversationCommands/welcomeSet.ts
@@ -12,7 +12,14 @@ const command: ConversationCommand = async (
 ) => {
   const { peer_id: peerId, text } = message;
 
-  const welcomeMessage = text.slice(text.indexOf(" ")).trim();
+  const indexOfSpace = text.indexOf(" ");
+
+  if (indexOfSpace === -1) {
+    await vk.messagesSend(peerId, phrase("welcomeSet_failNoMessage"));
+    return;
+  }
+
+  const welcomeMessage = text.slice(indexOfSpace).trim();
 
   if (welcomeMessage.length === 0) {
     await vk.messagesSend(peerId, phrase("welcomeSet_failNoMessage"));

--- a/commands/conversationCommands/welcomeTest.ts
+++ b/commands/conversationCommands/welcomeTest.ts
@@ -1,0 +1,42 @@
+import { ConversationCommand, ConversationCommandObject } from "..";
+import generateVkUserLink from "../../utils/generateVkUserLink";
+import phrase from "../../utils/localization/phrase";
+import vk from "../../utils/vk";
+
+const command: ConversationCommand = async (
+  message,
+  settings,
+  adminContext,
+  callbackServerSettings
+) => {
+  const { peer_id: peerId, text, from_id: fromId } = message;
+
+  if (settings.actionlessModes.welcome === null) {
+    await vk.messagesSend(peerId, phrase("welcomeTest_failModeIsDisabled"));
+    return;
+  }
+
+  const userLink = generateVkUserLink(
+    fromId,
+    adminContext?.profiles.get(fromId)?.first_name
+  );
+
+  const welcomeMessage =
+    settings.welcome ?? phrase("common_defaultWelcomeMessage");
+
+  await vk.messagesSend(
+    peerId,
+    phrase("common_welcome", {
+      userLink,
+      welcomeMessage,
+    })
+  );
+};
+
+const welcomeTest: ConversationCommandObject = {
+  command,
+  isAdminCommand: false,
+  description: "welcomeTest_description",
+};
+
+export default welcomeTest;

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -159,6 +159,7 @@ export const upcastToActionlessModeName = (value: string): ActionlessModeName =>
       [
         JsonDecoder.isExactly("ignoreUsers"),
         JsonDecoder.isExactly("ignoreUnknownCommands"),
+        JsonDecoder.isExactly("welcome"),
       ],
       "Actionless modes"
     )

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -8,6 +8,7 @@ import { MessageId } from "../utils/localization/messages";
 import { Message } from "../utils/vkCallbackDecoders/messageNewDecoder";
 import ignoreUnknownCommands from "./actionlessModes/ignoreUnknownCommands";
 import ignoreUsers from "./actionlessModes/ignoreUsers";
+import welcome from "./actionlessModes/welcome";
 import callbackDisconnect from "./callbackConversationCommands/callbackDisconnect";
 import kick from "./callbackConversationCommands/kick";
 import remove from "./callbackConversationCommands/remove";
@@ -25,6 +26,9 @@ import templateShow from "./conversationCommands/templateShow";
 import warningAmount from "./conversationCommands/warningAmount";
 import warningLimitSet from "./conversationCommands/warningLimitSet";
 import warningLimitShow from "./conversationCommands/warningLimitShow";
+import welcomeRemove from "./conversationCommands/welcomeRemove";
+import welcomeSet from "./conversationCommands/welcomeSet";
+import welcomeTest from "./conversationCommands/welcomeTest";
 import unwarn from "./conversationCommandsWithAdminContext/unwarn";
 import warn from "./conversationCommandsWithAdminContext/warn";
 import warningAdd from "./conversationCommandsWithAdminContext/warningAdd";
@@ -44,7 +48,7 @@ export type CallbackMode = (
   callbackServerSettings: CallbackServerSettings,
   botReacted: boolean,
   adminContext: AdminContext | null
-  ) => Promise<void>;
+) => Promise<void>;
 
 export type ConversationCommand = (
   message: Message,
@@ -119,7 +123,10 @@ export interface AdminContext {
   profiles: Map<number, User>;
 }
 
-export type ActionlessModeName = "ignoreUsers" | "ignoreUnknownCommands";
+export type ActionlessModeName =
+  | "ignoreUsers"
+  | "ignoreUnknownCommands"
+  | "welcome";
 
 export type ModeName = "echo";
 
@@ -130,6 +137,7 @@ const internalActionlessModes: {
 } = {
   ignoreUsers,
   ignoreUnknownCommands,
+  welcome,
 };
 
 const internalModes: { [commandName in ModeName]: ModeObject } = {
@@ -199,6 +207,9 @@ export const conversationCommands: {
   warningAmount,
   warningLimitSet,
   warningLimitShow,
+  welcomeRemove,
+  welcomeSet,
+  welcomeTest,
 };
 
 export const conversationCommandsWithAdminContext: {

--- a/utils/database/getChatSettings.ts
+++ b/utils/database/getChatSettings.ts
@@ -20,10 +20,15 @@ export interface ChatSettings {
     [userId: string]: number;
   };
   warningsLimit: number;
+  welcome: string | null;
 }
 
 const getDefaultSettings = (): ChatSettings => ({
-  actionlessModes: { ignoreUnknownCommands: null, ignoreUsers: null },
+  actionlessModes: {
+    ignoreUnknownCommands: null,
+    ignoreUsers: null,
+    welcome: null,
+  },
   modes: { echo: null },
   callbackModes: { stop: null, removeCommands: null, profanityFilter: null },
   callbackServerUserId: null,
@@ -31,6 +36,7 @@ const getDefaultSettings = (): ChatSettings => ({
   templates: {},
   warnings: {},
   warningsLimit: defaultWarningsLimit,
+  welcome: null,
 });
 
 const getChatSettings = async (peerId: number): Promise<ChatSettings> => {

--- a/utils/database/utils/chatSettingsDecoder.ts
+++ b/utils/database/utils/chatSettingsDecoder.ts
@@ -9,6 +9,7 @@ const chatSettingsDecoder = JsonDecoder.object<ChatSettings>(
       {
         ignoreUnknownCommands: optionalDecoder(JsonDecoder.isExactly(true)),
         ignoreUsers: optionalDecoder(JsonDecoder.isExactly(true)),
+        welcome: optionalDecoder(JsonDecoder.isExactly(true)),
       },
       "Actionless modes"
     ),
@@ -48,6 +49,7 @@ const chatSettingsDecoder = JsonDecoder.object<ChatSettings>(
       [JsonDecoder.number, JsonDecoder.isUndefined(defaultWarningsLimit)],
       "Warnings limit"
     ),
+    welcome: optionalDecoder(JsonDecoder.string),
   },
   "Chat settings"
 );

--- a/utils/handleMessage.ts
+++ b/utils/handleMessage.ts
@@ -2,6 +2,7 @@ import { User, VkError, VkErrorCode } from "vk-ts";
 import { ConversationMember } from "vk-ts/dist/methods/messagesGetConversationMembers";
 import { AdminContext } from "../commands";
 import getChatSettings from "./database/getChatSettings";
+import generateVkUserLink from "./generateVkUserLink";
 import getCallbackServerSettings from "./getCallbackServerSettings";
 import handleConversationMessage from "./handleConversationMessage";
 import handleModes from "./handleModes";
@@ -62,9 +63,37 @@ const handleMessage = async (message: Message) => {
       action !== null &&
       action.type === "chat_invite_user" &&
       action.member_id === -variables.groupId;
+
     if (botIsInvited) {
       await vk.messagesSend(peerId, phrase("common_hello"));
     }
+
+    const newUserJoined =
+      action !== null && action.type === "chat_invite_user_by_link";
+
+    if (newUserJoined) {
+      const [settings, adminContext] = await Promise.all([
+        getChatSettings(peerId),
+        getAdminContext(peerId, fromId),
+      ]);
+
+      const userLink = generateVkUserLink(
+        fromId,
+        adminContext?.profiles.get(fromId)?.first_name
+      );
+
+      const welcomeMessage =
+        settings.welcome ?? phrase("common_defaultWelcomeMessage");
+
+      await vk.messagesSend(
+        peerId,
+        phrase("common_welcome", {
+          userLink,
+          welcomeMessage,
+        })
+      );
+    }
+
     if (action === null) {
       const [settings, adminContext] = await Promise.all([
         getChatSettings(peerId),

--- a/utils/handleMessage.ts
+++ b/utils/handleMessage.ts
@@ -69,17 +69,23 @@ const handleMessage = async (message: Message) => {
     }
 
     const newUserJoined =
-      action !== null && action.type === "chat_invite_user_by_link";
+      (action !== null &&
+        action.type === "chat_invite_user_by_link" &&
+        fromId >= 0) ||
+      (action?.type === "chat_invite_user" && action.member_id >= 0);
 
     if (newUserJoined) {
+      const newUserId =
+        action?.type === "chat_invite_user" ? action.member_id : fromId;
+
       const [settings, adminContext] = await Promise.all([
         getChatSettings(peerId),
-        getAdminContext(peerId, fromId),
+        getAdminContext(peerId, newUserId),
       ]);
 
       const userLink = generateVkUserLink(
-        fromId,
-        adminContext?.profiles.get(fromId)?.first_name
+        newUserId,
+        adminContext?.profiles.get(newUserId)?.first_name
       );
 
       const welcomeMessage =

--- a/utils/localization/messages/en.ts
+++ b/utils/localization/messages/en.ts
@@ -129,6 +129,8 @@ const en = {
     "I tried to kick {userLink}, but there is a problem with your callback server. {modLink}, please kick { sex, select, male {him} female {her} unknown {them}} manualy and check your callback server",
   common_kickWithSomeonesCallbackServerFailed:
     "I tried to kick {userLink}, but there is a problem with the callback server. {modLink}, please kick { sex, select, male {him} female {her} unknown {them}} manualy and ask {callbackOwnerLink} to check { callbackOwnerSex, select, male {his} female {her} unknown {their}} callback server",
+  common_welcome: "{userLink}, {welcomeMessage}",
+  common_defaultWelcomeMessage: "hey there, welcome to the chat",
 
   echo_description: "echoes all new messages in the chat",
   echo_enabledText: "I'll be repeating all messages in the chat",
@@ -156,7 +158,7 @@ const en = {
   ignoreUsers_enabledText: "I will ignore commands from regular users",
 
   kick_description: "kicks user",
-  kick_failNoUserId: 'Type id of user to kick after the command name',
+  kick_failNoUserId: "Type id of user to kick after the command name",
   kick_willBeKicked: "Okay, I will kick {userLink}",
 
   profanityFilter_description: "deletes messages with Russian swear words",
@@ -165,9 +167,9 @@ const en = {
   profanityFilter_disabledText:
     "Okay, I won't remove messages with swear words anymore",
   profanityFilter_success:
-    "{userLink}, I warn you for using word \"{word}\". You have {count, plural, =0 {no warnings} one {1 warning out of {maxCount}} other {# warnings out of {maxCount}}}",
+    '{userLink}, I warn you for using word "{word}". You have {count, plural, =0 {no warnings} one {1 warning out of {maxCount}} other {# warnings out of {maxCount}}}',
   profanityFilter_willBeKickedWithCallback:
-    "{userLink}, I warn you for using word \"{word}\". Your amount of warnings has hit the limit of {maxCount}, so you will be kicked",
+    '{userLink}, I warn you for using word "{word}". Your amount of warnings has hit the limit of {maxCount}, so you will be kicked',
 
   remove_description: "removes message with this command",
 
@@ -272,10 +274,36 @@ const en = {
     "The limit of warnings per user is {warningsLimit}. User gets kicked if they reach the limit",
 
   warningRemove_description: "removes warning from user",
-  warningRemove_failNoUserId: 'Type id of user to unwarn after the command name',
+  warningRemove_failNoUserId:
+    "Type id of user to unwarn after the command name",
   warningRemove_faliNoWarnsAlready: "@id{id} ({name}) already has no warnings",
   warningRemove_success:
     "@id{id} ({name}) has been unwarned. { sex, select, male {He has} female {She has} unknown {They have}} {count, plural, =0 {no warnings} one {1 warning out of {maxCount}} other {# warnings out of {maxCount}}}",
+
+  welcome_description: "welcomes new users",
+  welcome_enabledText:
+    "I'll welcome new users in the chat. You can customize welcome message using /welcomeSet command. Also you can test welcome message using /welcomeTest command",
+  welcome_disabledText: "Okay, I'll stop welcoming new chat users",
+
+  welcomeRemove_description: "removes custom welcome message",
+  welcomeRemove_failNoMessage: "There's no saved welcome message",
+  welcomeRemove_failNoMessageWithModeHint:
+    "There's no saved welcome message. If you want me to stop welcoming new users, disable /welcome mode",
+  welcomeRemove_success: "I've removed custom welcome message",
+  welcomeRemove_successWithModeHint:
+    "I've removed custom welcome message, I will welcome new users with default welcome message. If you want me to stop welcoming new users, disable /welcome mode",
+
+  welcomeSet_description: "sets custom welcome message",
+  welcomeSet_failNoMessage:
+    "Type your custom welcome message after the command name",
+  welcomeSet_success:
+    "I've set custom welcome message. Use /welcomeTest command to test it",
+  welcomeSet_successWithModeHint:
+    "I've set custom welcome message. Don't forget to enable /welcome mode, so I will use this message to welcome new users",
+
+  welcomeTest_description: "shows wellcome message",
+  welcomeTest_failModeIsDisabled:
+    "Mode /welcome is disabled, so I can't show welcome message. Enable it so I will welcome new users",
 };
 
 export default en;

--- a/utils/vkCallbackDecoders/messageNewDecoder.ts
+++ b/utils/vkCallbackDecoders/messageNewDecoder.ts
@@ -1,8 +1,18 @@
+import { JsonDecoder } from "ts.data.json";
 import variables from "../variables";
 import vkCallbackWithObjectRequestDecoder, {
   VkCallbackRequestWithObject,
 } from "./vkCallbackWithObjectDecoder";
-import { JsonDecoder } from "ts.data.json";
+
+type Action =
+  | {
+      type: "chat_invite_user";
+      member_id: number;
+    }
+  | {
+      type: "chat_invite_user_by_link";
+    }
+  | null;
 
 export interface Message {
   id: number;
@@ -11,10 +21,7 @@ export interface Message {
   peer_id: number;
   from_id: number;
   conversation_message_id: number;
-  action: {
-    type: "chat_invite_user";
-    member_id: number;
-  } | null;
+  action: Action;
 }
 
 interface MessageNew {
@@ -29,12 +36,20 @@ const messageDecoder = JsonDecoder.object<Message>(
     peer_id: JsonDecoder.number,
     from_id: JsonDecoder.number,
     conversation_message_id: JsonDecoder.number,
-    action: JsonDecoder.oneOf(
+    action: JsonDecoder.oneOf<Action>(
       [
         JsonDecoder.object(
           {
             type: JsonDecoder.isExactly<"chat_invite_user">("chat_invite_user"),
             member_id: JsonDecoder.number,
+          },
+          "Action"
+        ),
+        JsonDecoder.object(
+          {
+            type: JsonDecoder.isExactly<"chat_invite_user_by_link">(
+              "chat_invite_user_by_link"
+            ),
           },
           "Action"
         ),


### PR DESCRIPTION
This pull request adds basic handling of unexpected errors. Also it allows bot to welcome new users in chat.

New modes:
/welcome - welcomes new users using default or custom welcome message

New commands:
/welcomeSet - sets custom welcome message
/welcomeRemove - removes custom welcome message, does not turn off /welcome mode
/welcomeTest - sends a test welcome message

Other changes:
- Add decoding of `chat_invite_user_by_link` event
- Reply with 'ok' and code 200 on error, so VK won't resend events
- Log unexpected errors